### PR TITLE
fix a jset bug when compare with 0

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -248,7 +248,7 @@ static int add_jump_set(struct codegen_ctxt *ctxt, __u32 what, int tloc,
     return floc;
   }
 
-  return add_jump(ctxt, BPF_K | BPF_JSET, what, tloc, floc);
+  return add_jump(ctxt, BPF_K | BPF_JSET, what, floc, tloc);
 }
 
 #define HIGH_WORD 0


### PR DESCRIPTION
when compile the following:
```
POLICY sample {
        ERRNO(22) {
        socket(domain, type, proto){
        (domain==2)&&(type&3!=0)
        }
        }
    }

USE sample DEFAULT ALLOW
```
produce wrong bpf bytecode the following:
```
l0:     ld [4]
l1:     jeq #0xc000003e, l3, l2
l2:     ret #0
l3:     ld [0]
l4:     jge #0x29, l5, l11
l5:     jge #0x2a, l11, l6
l6:     ld [16]
l7:     jeq #0x2, l8, l11
l8:     ld [24]
l9:     jset #0x3, l11, l10
l10:    ret #0x50016
l11:    ret #0x7fff0000
```
it should be the following:
```
l0:     ld [4]
l1:     jeq #0xc000003e, l3, l2
l2:     ret #0
l3:     ld [0]
l4:     jge #0x29, l5, l10
l5:     jge #0x2a, l10, l6
l6:     ld [16]
l7:     jeq #0x2, l8, l10
l8:     ld [24]
l9:     jset #0x3, l11, l10
l10:    ret #0x7fff0000
l11:    ret #0x50016
```

